### PR TITLE
Modificando datastructures.rst 

### DIFF
--- a/traducidos/datastructures.rst
+++ b/traducidos/datastructures.rst
@@ -461,7 +461,7 @@ discutiremos en la sección siguiente.
 Una pequeña demostración::
 
    >>> canasta = {'manzana', 'naranja', 'manzana', 'pera', 'naranja', 'banana'}
-   >>> print fruta                  # muestra que se removieron los duplicados
+   >>> print (canasta)                  # muestra que se removieron los duplicados
    {'pera', 'manzana', 'banana', 'naranja'}
    >>> 'naranja' in canasta         # verificación de pertenencia rápida
    True

--- a/traducidos/modules.rst
+++ b/traducidos/modules.rst
@@ -208,7 +208,7 @@ compilar módulos desde diferentes releases y versiones de Python para
 coexistir.
 
 Python chequea la fecha de modificación de la fuente contra la versión
-compilada para evr si esta es obsoleta y necesita ser
+compilada para ver si esta es obsoleta y necesita ser
 recompilada. Esto es un proceso completamente automático. También, los
 módulos compilados son independientes de la plataforma, así que la
 misma librería puede ser compartida a través de sistemas con


### PR DESCRIPTION
Cambiando 'print frutas', deberia decir 'print (canasta)' 

Son dos errores:
1. print llama a un conjunto inexistente
2. la llamada al comando print no es la que se usa en python3.x
