### PR TITLE
Migrate site to Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: traducidos/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.8

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,5 @@ formats: all
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.8
+  install:
+    - requirements: traducidos/requirements.txt

--- a/README.md
+++ b/README.md
@@ -9,17 +9,8 @@ Utilizando la carpeta Doc/tutorial y el archivo descargado fue este:
 
 La versión OnLine de esta documentación se puede encontrar en:
 
-* http://tutorial.python.org.ar/
+* https://tutorial.python.org.ar/
 
-Configurar entorno para generar el HTML / PDF
----------------------------------------------
-
-Hay un script (`dev/install_dependencies.sh`) que instala las
-dependencias necesarias para generar el tutorial en todos sus
-formatos.
-
-*Abrir el archivo ANTES de ejecutarlo para estar SEGUROS que hace lo
- que queremos...*
 
 Actualizar el tutorial
 ----------------------
@@ -47,22 +38,6 @@ haciendo los cambios en los archivos dentro del directorio
 
 1. Crear las versiones HTML, eBook y PDF (para crear esta version es
 necesario tener instalado `pdftk` 2.01):
-
- ```
- fab create_html
- fab create_ebook
- fab create_pdf
- fab change_htmlindex_version
- ```
-
-1. Verificar que el PDF y eBook se abre correctamente con Evince y Firefox
-(preview)
-
-1. Si tenés permisos de `admin` en el servidor, ejecutar:
-
- ```
- fab deploy_all
- ```
 
 1. Actualizar el README.md (la sección que indica qué versión del
    tutorial está traducida, al principio)

--- a/README.md
+++ b/README.md
@@ -43,17 +43,15 @@ necesario tener instalado `pdftk` 2.01):
    tutorial está traducida, al principio)
 
 1. Crear un commit para esta nueva revision:
-
- ```
- git commit -am "Actualización del tutorial"
- ```
+   ```
+   git commit -am "Actualización del tutorial"
+    ```
 
 1. Crear una etiqueta de git:
-
- ```
- git tag v3.6.3
- git push --tags
- ```
+   ```
+   git tag v3.6.3
+   git push --tags
+   ```
 
 1. Una vez actualizada la traducción, enviar un mail a la lista de
 correo de Python Argentina para informar sobre esta actualización.

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,21 @@
+Configurar entorno para generar el HTML / PDF
+---------------------------------------------
+
+Hay un script (`install_dependencies.sh`) que instala las
+dependencias necesarias para generar el tutorial en todos sus
+formatos.
+
+*Abrir el archivo ANTES de ejecutarlo para estar SEGUROS que hace lo
+ que queremos...*
+
+1. Crear las version HTML, eBook y PDF (para crear esta version es necesario
+   tener instalado `pdftk` 2.01):
+
+```
+fab create_html
+fab create_ebook
+fab create_pdf
+```
+
+1. Verificar que el PDF y eBook se abre correctamente con Evince y Firefox
+(preview)

--- a/traducidos/conf.py
+++ b/traducidos/conf.py
@@ -42,7 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Tutorial de Python'
-copyright = u'2017, Python Software Foundation'
+copyright = u'2020, Python Software Foundation'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/traducidos/conf.py
+++ b/traducidos/conf.py
@@ -11,6 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import os
 import sphinx_bootstrap_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -22,7 +23,10 @@ import sphinx_bootstrap_theme
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'rst2pdf.pdfbuilder']
+extensions = ['sphinx.ext.autodoc']
+
+if not os.environ.get('READTHEDOCS', None):
+    extensions.append('rst2pdf.pdfbuilder')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/traducidos/requirements.txt
+++ b/traducidos/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_bootstrap_theme


### PR DESCRIPTION
Built docs at https://python-tutorial-es--28.org.readthedocs.build/

Things to consider:

- [ ] PDF builder is not `rst2pdf` in Read the Docs (but it [builds properly](https://python-tutorial-es.readthedocs.io/_/downloads/en/readthedocs/pdf/))
- [ ] We don't have the index page anymore (http://docs.python.org.ar/tutorial/)
- [ ] We should kill 2.7 docs
- [ ] Probably Django 1.8 as well
- [ ] We need to add a CNAME in the DNS (see https://docs.readthedocs.io/en/stable/custom_domains.html) to use https://tutorial.python.org.ar

Closes https://github.com/PyAr/pyar_infra/issues/47